### PR TITLE
Make local library files drive command CRUD

### DIFF
--- a/electron/main/github.ts
+++ b/electron/main/github.ts
@@ -907,6 +907,16 @@ function slugify(title: string): string {
         || 'untitled'
 }
 
+function createCommandId(): string {
+    return crypto.randomUUID().toLowerCase()
+}
+
+function normalizeCommandId(value: unknown): string | null {
+    return typeof value === 'string' && /^[0-9a-f-]{36}$/.test(value)
+        ? value.toLowerCase()
+        : null
+}
+
 export async function publishCommand(
     libraryId: number,
     command: { title: string; body: string; description: string; tags: string[]; language: string }
@@ -930,6 +940,7 @@ export async function publishCommand(
     const now = new Date().toISOString()
     const commandJson = {
         snipforge: 'command' as const,
+        id: createCommandId(),
         title: command.title,
         body: command.body,
         description: command.description || '',
@@ -950,6 +961,10 @@ export async function publishCommand(
         try {
             const existingContent = Buffer.from(existing.content, 'base64').toString('utf8')
             const existingCommand = JSON.parse(existingContent)
+            const existingId = normalizeCommandId(existingCommand.id)
+            if (existingId) {
+                commandJson.id = existingId
+            }
             if (existingCommand.created_at) {
                 commandJson.created_at = existingCommand.created_at
             }

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -956,6 +956,53 @@ ipcMain.handle('library:setupDefaultWritableLocalLibrary', async () => {
   }
 })
 
+ipcMain.handle('library:createCommand', async (_, command: { title: string; body: string; description: string; tags: string; language: string }) => {
+  if (
+    !isValidCommandUpdate(command) ||
+    typeof command.title !== 'string' ||
+    typeof command.body !== 'string' ||
+    !command.title.trim() ||
+    !command.body.trim()
+  ) {
+    return { success: false, error: 'Invalid command data' }
+  }
+  try {
+    return await localLibrary.createLocalLibraryCommand(command)
+  } catch (error) {
+    console.error('Library createCommand error:', error)
+    return { success: false, error: (error as Error).message }
+  }
+})
+
+ipcMain.handle('library:updateCommand', async (_, id: number, updates: { title: string; body: string; description: string; tags: string; language: string }) => {
+  if (
+    typeof id !== 'number' ||
+    !isValidCommandUpdate(updates) ||
+    !updates.title.trim() ||
+    !updates.body.trim()
+  ) {
+    return { success: false, error: 'Invalid parameters' }
+  }
+  try {
+    return await localLibrary.updateLocalLibraryCommand(id, updates)
+  } catch (error) {
+    console.error('Library updateCommand error:', error)
+    return { success: false, error: (error as Error).message }
+  }
+})
+
+ipcMain.handle('library:deleteCommand', async (_, id: number) => {
+  if (typeof id !== 'number') {
+    return { success: false, error: 'Invalid ID' }
+  }
+  try {
+    return await localLibrary.deleteLocalLibraryCommand(id)
+  } catch (error) {
+    console.error('Library deleteCommand error:', error)
+    return { success: false, error: (error as Error).message }
+  }
+})
+
 ipcMain.handle('library:exportZip', async (_, commandIds: number[], name: string, description: string) => {
   if (!win) return { success: false, error: 'No window' }
   try {

--- a/electron/main/local-library.ts
+++ b/electron/main/local-library.ts
@@ -5,7 +5,7 @@ import crypto from 'node:crypto'
 import AdmZip from 'adm-zip'
 import * as db from './database'
 import * as settings from './settings'
-import type { Library, LibraryManifest, RemoteCommand, SyncResult } from '../../shared/types'
+import type { CommandMutationResult, Library, LibraryManifest, RemoteCommand, SyncResult } from '../../shared/types'
 
 // ── Local Folder Scanning ────────────────────────────────────────
 
@@ -13,6 +13,14 @@ interface ScanResult {
     manifest: LibraryManifest
     manifestPath: string
     commands: Array<{ path: string; command: RemoteCommand }>
+}
+
+interface CommandFormData {
+    title: string
+    body: string
+    description: string
+    tags: string
+    language: string
 }
 
 function deriveLibraryName(folderPath: string): string {
@@ -48,6 +56,76 @@ export function getDefaultWritableLocalLibrary(): Library | null {
 
 export function setDefaultWritableLocalLibrary(libraryId: number): void {
     settings.set('library.defaultWritableLocalLibraryId', libraryId)
+}
+
+function parseTags(tags: string): string[] {
+    try {
+        const parsed = JSON.parse(tags)
+        return Array.isArray(parsed) ? parsed.filter(tag => typeof tag === 'string') : []
+    } catch {
+        return []
+    }
+}
+
+function buildCommandFileData(command: CommandFormData, createdAt: string): {
+    snipforge: 'command'
+    title: string
+    body: string
+    description: string
+    tags: string[]
+    language: string
+    created_at: string
+    updated_at: string
+} {
+    const now = new Date().toISOString()
+    return {
+        snipforge: 'command',
+        title: command.title.trim(),
+        body: command.body.trim(),
+        description: command.description || '',
+        tags: parseTags(command.tags),
+        language: command.language || 'plaintext',
+        created_at: createdAt,
+        updated_at: now,
+    }
+}
+
+async function writeCommandFile(folderPath: string, fileName: string, command: CommandFormData, createdAt: string): Promise<void> {
+    const fileData = buildCommandFileData(command, createdAt)
+    await fs.writeFile(
+        path.join(folderPath, fileName),
+        JSON.stringify(fileData, null, 2) + '\n',
+        'utf8'
+    )
+}
+
+async function findUniqueCommandFileName(folderPath: string, title: string): Promise<string> {
+    const baseName = slugify(title)
+    let counter = 0
+
+    while (true) {
+        const fileName = counter === 0 ? `${baseName}.json` : `${baseName}-${counter + 1}.json`
+        try {
+            await fs.access(path.join(folderPath, fileName))
+            counter += 1
+        } catch {
+            return fileName
+        }
+    }
+}
+
+function resolveFileBackedLocalCommand(commandId: number): { command: db.Command; library: Library } | null {
+    const command = db.getAllCommands().find(c => c.id === commandId)
+    if (!command || command.source !== 'remote' || !command.library_id || !command.remote_path) {
+        return null
+    }
+
+    const library = db.getAllLibraries().find(l => l.id === command.library_id)
+    if (!isInitializedLocalLibrary(library)) {
+        return null
+    }
+
+    return { command, library }
 }
 
 async function readFolderManifest(folderPath: string): Promise<ScanResult | null> {
@@ -150,6 +228,73 @@ async function indexLocalLibrary(folderPath: string, options: { ensureManifest: 
     )
     const library = db.getLibraryByRepo(folderPath)!
     return { library, syncResult }
+}
+
+export async function createLocalLibraryCommand(command: CommandFormData): Promise<CommandMutationResult> {
+    const library = getDefaultWritableLocalLibrary()
+    if (!library) {
+        const id = db.addCommand({
+            title: command.title,
+            body: command.body,
+            description: command.description,
+            tags: command.tags,
+            language: command.language,
+            source: 'local',
+            library_id: null,
+            remote_path: null,
+        })
+        return { success: id > 0, mode: 'database' }
+    }
+
+    const fileName = await findUniqueCommandFileName(library.github_repo, command.title)
+    const createdAt = new Date().toISOString()
+    await writeCommandFile(library.github_repo, fileName, command, createdAt)
+
+    const syncResult = await syncLocalLibrary(library.id, true)
+    const updatedLibrary = db.getAllLibraries().find(l => l.id === library.id) || library
+    return { success: true, mode: 'library', library: updatedLibrary, syncResult }
+}
+
+export async function updateLocalLibraryCommand(commandId: number, updates: CommandFormData): Promise<CommandMutationResult> {
+    const target = resolveFileBackedLocalCommand(commandId)
+    if (!target) {
+        const success = db.updateCommand(commandId, {
+            title: updates.title,
+            body: updates.body,
+            description: updates.description,
+            tags: updates.tags,
+            language: updates.language,
+        })
+        return { success, mode: 'database' }
+    }
+
+    const filePath = path.join(target.library.github_repo, target.command.remote_path)
+    const existing = await fs.readFile(filePath, 'utf8').then(content => JSON.parse(content) as {
+        created_at?: string
+    }).catch(() => null)
+
+    if (!existing) {
+        throw new Error('Command file not found')
+    }
+
+    await writeCommandFile(target.library.github_repo, target.command.remote_path, updates, existing.created_at || target.command.created_at)
+    const syncResult = await syncLocalLibrary(target.library.id, true)
+    const updatedLibrary = db.getAllLibraries().find(l => l.id === target.library.id) || target.library
+    return { success: true, mode: 'library', library: updatedLibrary, syncResult }
+}
+
+export async function deleteLocalLibraryCommand(commandId: number): Promise<CommandMutationResult> {
+    const target = resolveFileBackedLocalCommand(commandId)
+    if (!target) {
+        const success = db.deleteCommand(commandId)
+        return { success, mode: 'database' }
+    }
+
+    const filePath = path.join(target.library.github_repo, target.command.remote_path)
+    await fs.rm(filePath, { force: true })
+    const syncResult = await syncLocalLibrary(target.library.id, true)
+    const updatedLibrary = db.getAllLibraries().find(l => l.id === target.library.id) || target.library
+    return { success: true, mode: 'library', library: updatedLibrary, syncResult }
 }
 
 export async function scanLocalFolder(folderPath: string): Promise<ScanResult> {

--- a/electron/main/local-library.ts
+++ b/electron/main/local-library.ts
@@ -67,8 +67,19 @@ function parseTags(tags: string): string[] {
     }
 }
 
-function buildCommandFileData(command: CommandFormData, createdAt: string): {
+function normalizeCommandId(value: unknown): string | null {
+    return typeof value === 'string' && /^[0-9a-f-]{36}$/.test(value)
+        ? value.toLowerCase()
+        : null
+}
+
+function createCommandId(): string {
+    return crypto.randomUUID().toLowerCase()
+}
+
+function buildCommandFileData(command: CommandFormData, createdAt: string, id: string): {
     snipforge: 'command'
+    id: string
     title: string
     body: string
     description: string
@@ -80,6 +91,7 @@ function buildCommandFileData(command: CommandFormData, createdAt: string): {
     const now = new Date().toISOString()
     return {
         snipforge: 'command',
+        id,
         title: command.title.trim(),
         body: command.body.trim(),
         description: command.description || '',
@@ -90,8 +102,8 @@ function buildCommandFileData(command: CommandFormData, createdAt: string): {
     }
 }
 
-async function writeCommandFile(folderPath: string, fileName: string, command: CommandFormData, createdAt: string): Promise<void> {
-    const fileData = buildCommandFileData(command, createdAt)
+async function writeCommandFile(folderPath: string, fileName: string, command: CommandFormData, createdAt: string, id: string): Promise<void> {
+    const fileData = buildCommandFileData(command, createdAt, id)
     await fs.writeFile(
         path.join(folderPath, fileName),
         JSON.stringify(fileData, null, 2) + '\n',
@@ -248,7 +260,7 @@ export async function createLocalLibraryCommand(command: CommandFormData): Promi
 
     const fileName = await findUniqueCommandFileName(library.github_repo, command.title)
     const createdAt = new Date().toISOString()
-    await writeCommandFile(library.github_repo, fileName, command, createdAt)
+    await writeCommandFile(library.github_repo, fileName, command, createdAt, createCommandId())
 
     const syncResult = await syncLocalLibrary(library.id, true)
     const updatedLibrary = db.getAllLibraries().find(l => l.id === library.id) || library
@@ -270,6 +282,7 @@ export async function updateLocalLibraryCommand(commandId: number, updates: Comm
 
     const filePath = path.join(target.library.github_repo, target.command.remote_path)
     const existing = await fs.readFile(filePath, 'utf8').then(content => JSON.parse(content) as {
+        id?: string
         created_at?: string
     }).catch(() => null)
 
@@ -277,7 +290,13 @@ export async function updateLocalLibraryCommand(commandId: number, updates: Comm
         throw new Error('Command file not found')
     }
 
-    await writeCommandFile(target.library.github_repo, target.command.remote_path, updates, existing.created_at || target.command.created_at)
+    await writeCommandFile(
+        target.library.github_repo,
+        target.command.remote_path,
+        updates,
+        existing.created_at || target.command.created_at,
+        normalizeCommandId(existing.id) || createCommandId()
+    )
     const syncResult = await syncLocalLibrary(target.library.id, true)
     const updatedLibrary = db.getAllLibraries().find(l => l.id === target.library.id) || target.library
     return { success: true, mode: 'library', library: updatedLibrary, syncResult }
@@ -341,6 +360,7 @@ export async function scanLocalFolder(folderPath: string): Promise<ScanResult> {
                 typeof parsed.body === 'string' && parsed.body.trim()
             ) {
                 const command: RemoteCommand = {
+                    id: normalizeCommandId(parsed.id) || undefined,
                     title: parsed.title,
                     body: parsed.body,
                     description: parsed.description || '',
@@ -640,6 +660,7 @@ async function readCommandFile(filePath: string): Promise<RemoteCommand | null> 
             typeof parsed.body === 'string' && parsed.body.trim()
         ) {
             return {
+                id: normalizeCommandId(parsed.id) || undefined,
                 title: parsed.title,
                 body: parsed.body,
                 description: parsed.description || '',

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron"
-import type { Command, Library, SyncResult, AuthStatus, GitHubUser, BulkPublishResult, UpdateStatus, DiscoveredLibrary, DefaultWritableLibraryResult, DefaultWritableLibrarySetupResult } from "../../shared/types"
+import type { Command, Library, SyncResult, AuthStatus, GitHubUser, BulkPublishResult, UpdateStatus, DiscoveredLibrary, DefaultWritableLibraryResult, DefaultWritableLibrarySetupResult, CommandMutationResult } from "../../shared/types"
 //expose db methods to renderer process
 contextBridge.exposeInMainWorld('electronAPI', {
   // db methods
@@ -95,6 +95,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('library:getDefaultWritableLocalLibrary'),
     setupDefaultWritableLocalLibrary: (): Promise<DefaultWritableLibrarySetupResult> =>
       ipcRenderer.invoke('library:setupDefaultWritableLocalLibrary'),
+    createCommand: (command: { title: string; body: string; description: string; tags: string; language: string }): Promise<CommandMutationResult> =>
+      ipcRenderer.invoke('library:createCommand', command),
+    updateCommand: (id: number, updates: { title: string; body: string; description: string; tags: string; language: string }): Promise<CommandMutationResult> =>
+      ipcRenderer.invoke('library:updateCommand', id, updates),
+    deleteCommand: (id: number): Promise<CommandMutationResult> =>
+      ipcRenderer.invoke('library:deleteCommand', id),
     browse: (repoUrl: string): Promise<{ success: boolean; manifest?: any; commands?: any[]; error?: string }> =>
       ipcRenderer.invoke('library:browse', repoUrl),
     openLocal: (): Promise<{ success: boolean; library?: Library; syncResult?: SyncResult; error?: string }> =>
@@ -193,6 +199,9 @@ declare global {
         getAll: () => Promise<Library[]>
         getDefaultWritableLocalLibrary: () => Promise<DefaultWritableLibraryResult>
         setupDefaultWritableLocalLibrary: () => Promise<DefaultWritableLibrarySetupResult>
+        createCommand: (command: { title: string; body: string; description: string; tags: string; language: string }) => Promise<CommandMutationResult>
+        updateCommand: (id: number, updates: { title: string; body: string; description: string; tags: string; language: string }) => Promise<CommandMutationResult>
+        deleteCommand: (id: number) => Promise<CommandMutationResult>
         browse: (repoUrl: string) => Promise<{ success: boolean; manifest?: any; commands?: any[]; error?: string }>
         openLocal: () => Promise<{ success: boolean; library?: Library; syncResult?: SyncResult; error?: string }>
         init: (libraryId: number, name: string, description: string, subpath?: string) => Promise<{ success: boolean; library?: Library; syncResult?: SyncResult; error?: string }>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -119,3 +119,11 @@ export interface DefaultWritableLibrarySetupResult {
   cancelled?: boolean
   error?: string
 }
+
+export interface CommandMutationResult {
+  success: boolean
+  mode?: 'library' | 'database'
+  library?: Library
+  syncResult?: SyncResult
+  error?: string
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -40,6 +40,7 @@ export interface Library {
 }
 
 export interface RemoteCommand {
+  id?: string
   title: string
   body: string
   description: string

--- a/src/App.vue
+++ b/src/App.vue
@@ -636,7 +636,7 @@ const processImport = async (commandsToAdd: ImportCommand[], idsToReplace: numbe
     // Delete existing commands if replacing
     if (idsToReplace.length > 0) {
       for (const id of idsToReplace) {
-        await window.electronAPI.database.deleteCommand(id)
+        await window.electronAPI.library.deleteCommand(id)
       }
     }
 
@@ -646,7 +646,7 @@ const processImport = async (commandsToAdd: ImportCommand[], idsToReplace: numbe
 
     for (const command of commandsToAdd) {
       try {
-        const addResult = await window.electronAPI.database.addCommand(command)
+        const addResult = await window.electronAPI.library.createCommand(command)
         if (addResult.success) {
           successCount++
         } else {
@@ -717,7 +717,7 @@ const handleBulkDelete = async (ids: number[]) => {
 
     for (const id of ids) {
       try {
-        const result = await window.electronAPI.database.deleteCommand(id)
+        const result = await window.electronAPI.library.deleteCommand(id)
         if (result.success) {
           successCount++
         } else {
@@ -802,7 +802,7 @@ const deleteCommand = async (id: number) => {
   if (!confirmDelete) return
   // Call the API to delete the command
   try {
-    const result = await window.electronAPI.database.deleteCommand(id)
+    const result = await window.electronAPI.library.deleteCommand(id)
     if (result.success) {
       showNotificationToast('Command deleted')
       // refresh the command list and clear selection
@@ -897,7 +897,7 @@ const deleteCommand = async (id: number) => {
     try {
       if (modalMode.value === 'edit' && selectedCommandForEdit.value) {
         // Update existing command
-        const result = await window.electronAPI.database.updateCommand(selectedCommandForEdit.value.id,
+        const result = await window.electronAPI.library.updateCommand(selectedCommandForEdit.value.id,
   formData)
         if (result.success) {
           showNotificationToast('Command updated')
@@ -908,7 +908,7 @@ const deleteCommand = async (id: number) => {
         }
       } else {
         // Add new command
-        const result = await window.electronAPI.database.addCommand(formData)
+        const result = await window.electronAPI.library.createCommand(formData)
         if (result.success) {
           showNotificationToast('Command added')
           await loadCommands()

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -63,6 +63,9 @@ interface Window {
       getAll: () => Promise<any[]>
       getDefaultWritableLocalLibrary: () => Promise<{ success: boolean; library: any | null; error?: string }>
       setupDefaultWritableLocalLibrary: () => Promise<{ success: boolean; library?: any; syncResult?: any; cancelled?: boolean; error?: string }>
+      createCommand: (command: { title: string; body: string; description: string; tags: string; language: string }) => Promise<import('../shared/types').CommandMutationResult>
+      updateCommand: (id: number, updates: { title: string; body: string; description: string; tags: string; language: string }) => Promise<import('../shared/types').CommandMutationResult>
+      deleteCommand: (id: number) => Promise<import('../shared/types').CommandMutationResult>
       browse: (repoUrl: string) => Promise<{ success: boolean; manifest?: any; commands?: any[]; error?: string }>
       openLocal: () => Promise<{ success: boolean; library?: any; syncResult?: any; error?: string }>
       init: (libraryId: number, name: string, description: string, subpath?: string) => Promise<{ success: boolean; library?: any; syncResult?: any; error?: string }>

--- a/tests/local-library.test.ts
+++ b/tests/local-library.test.ts
@@ -2,15 +2,25 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import path from 'node:path'
 import os from 'node:os'
 import { promises as fs } from 'node:fs'
-import { scanLocalFolder, slugify } from '../electron/main/local-library'
+import * as db from '../electron/main/database'
+import {
+    createLocalLibraryCommand,
+    deleteLocalLibraryCommand,
+    scanLocalFolder,
+    setupDefaultWritableLocalLibrary,
+    slugify,
+    updateLocalLibraryCommand,
+} from '../electron/main/local-library'
 
 let tmpDir: string
 
 beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snipforge-test-lib-'))
+    db.initializeDatabase(path.join(tmpDir, 'test.db'))
 })
 
 afterEach(async () => {
+    db.closeDatabase()
     await fs.rm(tmpDir, { recursive: true, force: true })
 })
 
@@ -181,5 +191,82 @@ describe('scanLocalFolder', () => {
 
         const result = await scanLocalFolder(tmpDir)
         expect(result.commands).toHaveLength(0)
+    })
+})
+
+describe('local library CRUD', () => {
+    it('writes created commands to disk, then updates and deletes the same file', async () => {
+        const setup = await setupDefaultWritableLocalLibrary(tmpDir)
+        const createResult = await createLocalLibraryCommand({
+            title: 'Git Commit',
+            body: 'git commit -m "msg"',
+            description: 'Initial command',
+            tags: '["git", "commit"]',
+            language: 'bash',
+        })
+
+        expect(createResult.success).toBe(true)
+        expect(createResult.mode).toBe('library')
+
+        const createdCommands = db.getRemoteCommands(setup.library.id)
+        expect(createdCommands).toHaveLength(1)
+
+        const commandId = createdCommands[0].id
+        const commandPath = createdCommands[0].remote_path as string
+        const createdFile = JSON.parse(await fs.readFile(path.join(tmpDir, commandPath), 'utf8'))
+        expect(createdFile.snipforge).toBe('command')
+        expect(createdFile.title).toBe('Git Commit')
+        expect(createdFile.tags).toEqual(['git', 'commit'])
+
+        const updateResult = await updateLocalLibraryCommand(commandId, {
+            title: 'Git Commit Updated',
+            body: 'git commit --amend',
+            description: 'Updated command',
+            tags: '["git", "amend"]',
+            language: 'bash',
+        })
+
+        expect(updateResult.success).toBe(true)
+        expect(updateResult.mode).toBe('library')
+
+        const updatedFile = JSON.parse(await fs.readFile(path.join(tmpDir, commandPath), 'utf8'))
+        expect(updatedFile.title).toBe('Git Commit Updated')
+        expect(updatedFile.body).toBe('git commit --amend')
+
+        const deleteResult = await deleteLocalLibraryCommand(commandId)
+        expect(deleteResult.success).toBe(true)
+        expect(deleteResult.mode).toBe('library')
+        await expect(fs.access(path.join(tmpDir, commandPath))).rejects.toThrow()
+        expect(db.getRemoteCommands(setup.library.id)).toHaveLength(0)
+    })
+
+    it('falls back to database CRUD for legacy DB-only commands', async () => {
+        const commandId = db.addCommand({
+            title: 'Legacy Command',
+            body: 'echo legacy',
+            description: '',
+            tags: '[]',
+            language: 'bash',
+            source: 'local',
+            library_id: null,
+            remote_path: null,
+        })
+
+        const updateResult = await updateLocalLibraryCommand(commandId, {
+            title: 'Legacy Command Updated',
+            body: 'echo legacy updated',
+            description: 'still local',
+            tags: '["legacy"]',
+            language: 'bash',
+        })
+
+        expect(updateResult.success).toBe(true)
+        expect(updateResult.mode).toBe('database')
+        expect(db.getAllCommands()[0].title).toBe('Legacy Command Updated')
+
+        const deleteResult = await deleteLocalLibraryCommand(commandId)
+        expect(deleteResult.success).toBe(true)
+        expect(deleteResult.mode).toBe('database')
+        expect(db.getAllCommands()).toHaveLength(0)
     })
 })

--- a/tests/local-library.test.ts
+++ b/tests/local-library.test.ts
@@ -195,7 +195,7 @@ describe('scanLocalFolder', () => {
 })
 
 describe('local library CRUD', () => {
-    it('writes created commands to disk, then updates and deletes the same file', async () => {
+    it('writes created commands to disk with a stable id, then updates and deletes the same file', async () => {
         const setup = await setupDefaultWritableLocalLibrary(tmpDir)
         const createResult = await createLocalLibraryCommand({
             title: 'Git Commit',
@@ -215,6 +215,7 @@ describe('local library CRUD', () => {
         const commandPath = createdCommands[0].remote_path as string
         const createdFile = JSON.parse(await fs.readFile(path.join(tmpDir, commandPath), 'utf8'))
         expect(createdFile.snipforge).toBe('command')
+        expect(createdFile.id).toMatch(/^[0-9a-f-]{36}$/)
         expect(createdFile.title).toBe('Git Commit')
         expect(createdFile.tags).toEqual(['git', 'commit'])
 
@@ -230,6 +231,7 @@ describe('local library CRUD', () => {
         expect(updateResult.mode).toBe('library')
 
         const updatedFile = JSON.parse(await fs.readFile(path.join(tmpDir, commandPath), 'utf8'))
+        expect(updatedFile.id).toBe(createdFile.id)
         expect(updatedFile.title).toBe('Git Commit Updated')
         expect(updatedFile.body).toBe('git commit --amend')
 


### PR DESCRIPTION
## Summary
- route command create/edit/delete through local-library file writes when a writable local library owns the command
- keep subscribed remote libraries read-only and preserve DB fallback behavior for legacy DB-only commands
- add targeted tests for file-backed create/update/delete and legacy fallback behavior

## Testing
- pnpm vue-tsc --noEmit
- pnpm vitest run tests/local-library.test.ts
- pnpm test:db

Depends on #20
Closes #21