### PR TITLE
fix: route bulk export through shared utility

### DIFF
--- a/docs/remote-libraries.md
+++ b/docs/remote-libraries.md
@@ -445,6 +445,9 @@ Every SnipForge file format gets a top-level `"snipforge"` field so the app can 
 - Old bundles without `snipforge: "bundle"` still import via `version` + `commands` check
 - Old command files without `snipforge: "command"` still validate via `title` + `body` check
 
+**Follow-up consistency work:**
+- [x] Bulk export now routes through `importExport.ts:exportCommands()` so all bundle exports share the same metadata shape and `snipforge: "bundle"` identity (issue [#33](https://github.com/ArtluxDM/SnipForge/issues/33))
+
 **Implementation notes:**
 - Import gains single-command support as a side effect: `validateExportData()` detects `snipforge: "command"` or bare `title`+`body` files and wraps them as a one-item bundle. This means any command JSON file (from a library, publish, or export) is directly importable via the import dialog.
 - Manifest detection shows a user-friendly error pointing to "Open Folder" instead of a cryptic validation failure.

--- a/src/App.vue
+++ b/src/App.vue
@@ -711,22 +711,8 @@ const handleBulkExport = async (ids: number[]) => {
   if (ids.length === 0) return
 
   try {
-    // Get selected commands
     const selectedCommands = commands.value.filter(cmd => ids.includes(cmd.id))
-
-    // Create export data
-    const exportData = {
-      version: '2.0',
-      export_date: new Date().toISOString(),
-      total_commands: selectedCommands.length,
-      commands: selectedCommands.map(cmd => ({
-        title: cmd.title,
-        body: cmd.body,
-        description: cmd.description,
-        tags: JSON.parse(cmd.tags),
-        language: cmd.language
-      }))
-    }
+    const exportData = exportCommands(selectedCommands)
 
     const filename = `snipforge_selected_${selectedCommands.length}_commands.json`
 

--- a/tests/import-export.test.ts
+++ b/tests/import-export.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { exportCommands, generateExportFilename } from '../src/utils/importExport'
+import type { Command } from '../shared/types'
+
+function makeCommand(overrides: Partial<Command> = {}): Command {
+    return {
+        id: 1,
+        title: 'Docker Logs',
+        body: 'docker logs -f api',
+        description: 'Tail API logs',
+        tags: '["docker", "Logs"]',
+        language: 'bash',
+        source: 'local',
+        library_id: null,
+        remote_path: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+        ...overrides,
+    }
+}
+
+describe('exportCommands', () => {
+    it('builds bundle exports with the shared metadata shape', () => {
+        const exportData = exportCommands([
+            makeCommand(),
+            makeCommand({
+                id: 2,
+                title: 'Kubectl Pods',
+                body: 'kubectl get pods',
+                description: '',
+                tags: '["k8s"]',
+                language: 'plaintext',
+            }),
+        ])
+
+        expect(exportData.snipforge).toBe('bundle')
+        expect(exportData.version).toBe('2.0')
+        expect(exportData.total_commands).toBe(2)
+        expect(exportData.exported_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+        expect(exportData.commands).toEqual([
+            {
+                title: 'Docker Logs',
+                body: 'docker logs -f api',
+                description: 'Tail API logs',
+                tags: ['docker', 'logs'],
+                language: 'bash',
+                created_at: '2026-01-01T00:00:00.000Z',
+                updated_at: '2026-01-02T00:00:00.000Z',
+            },
+            {
+                title: 'Kubectl Pods',
+                body: 'kubectl get pods',
+                description: '',
+                tags: ['k8s'],
+                language: 'plaintext',
+                created_at: '2026-01-01T00:00:00.000Z',
+                updated_at: '2026-01-02T00:00:00.000Z',
+            },
+        ])
+    })
+
+    it('records normalized filter tags when a filtered export is requested', () => {
+        const exportData = exportCommands([makeCommand()], ['Docker', ' logs '])
+
+        expect(exportData.filter_tags).toEqual(['docker', 'logs'])
+    })
+})
+
+describe('generateExportFilename', () => {
+    it('uses the shared filename format for filtered exports', () => {
+        expect(generateExportFilename(['docker', 'logs'])).toMatch(/^snipforge-commands_docker-logs_\d{4}-\d{2}-\d{2}\.json$/)
+    })
+})


### PR DESCRIPTION
## Summary
- route bulk export through the shared `exportCommands()` utility
- add regression coverage for the shared bundle export shape
- document the bundle-export consistency follow-up in the remote libraries doc

fixes #33
