### PR TITLE
feat: make libraries the default writable command store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ QUIZZES.md
 
 # Local ideas / feature brainstorming (not tracked)
 .ideas/
+
+# Local runtime/build caches
+.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,21 @@
-# CLAUDE.md
-
-This file is the behavioral guide and knowledge map for Claude Code working on this project. Keep it lean — point to docs, don't duplicate them. Update it when how we work changes, not by appending but by editing.
+---
+title: "snipforge"
+tags: [project, electron, desktop, active]
+status: active
+cluster: snipforge
+tech: [electron, vue3, typescript, sqlite, vite, fuse.js]
+related:
+  - "[[snipforge-website/CLAUDE]]"
+  - "[[home-lab/CLAUDE]]"
+---
 
 ## What This Is
 
 SnipForge is a desktop app (Electron + Vue 3 + TypeScript) for saving, searching, and managing command snippets. Global hotkey opens a palette, you search, you copy. The user is an engineer/human/ai_agent who needs commands/snippets fast — every UX decision serves that.
 
-## How We Work
+## Workflow
 
-**We are co-developers.** Challenge bad ideas, propose better approaches, make architectural decisions together. No hand-holding, no unnecessary explanations — but when we're in new territory, think out loud so we both learn.
-
-**Doc-first workflow:**
+**Doc-first:**
 1. Update the feature doc with the plan before writing code
 2. Implement, referencing the GitHub issue in commits (`ref #N` or `fixes #N`)
 3. Update the feature doc with final notes and mark deliverables complete
@@ -21,8 +26,6 @@ SnipForge is a desktop app (Electron + Vue 3 + TypeScript) for saving, searching
 **User-first mindset.** We're not building code for code's sake. Every feature exists because a person needs it. Think about how functional it is for the end user — that's the driver, not how fancy the implementation is.
 
 **Context management.** For large features, split into two issues: backend (#N-backend) and frontend (#N-frontend). Backend session handles main process, SQLite, IPC, types. Frontend session starts fresh with clean context and handles Vue components, styles, visual verification. This avoids hallucinations from context pressure. Chrome DevTools MCP is available directly for screenshots and visual verification (`pnpm dev:debug`). See `.claude/README.md` for available agents.
-
-**This file is part of the workflow.** When how we work changes, CLAUDE.md gets updated in the same commit. Don't append endlessly — edit to keep it current.
 
 ## Tech Stack
 
@@ -69,6 +72,7 @@ Feature documentation lives in `docs/`. These are living documents — plan, imp
 | Doc | What | Status |
 |-----|------|--------|
 | `docs/schema.md` | Database schema — tables, columns, migrations, TypeScript types | Living reference |
+| `docs/library-first-command-storage.md` | Library-first command model — filesystem source of truth, SQLite as cache/index, roadmap and issue plan | Planned |
 | `docs/remote-libraries.md` | Remote Libraries — GitHub sync, publishing, unified library model | Phases 1-4 complete, Phase 5 planned |
 | `docs/settings.md` | Settings — infrastructure, General tab, connectors, auto-sync, shortcuts | Phases 1-3 complete |
 | `docs/variable-substitution.md` | Variable substitution — `{{variable}}` templates, copy flow, highlighting | Current state documented, #11 planned |

--- a/docs/library-first-command-storage.md
+++ b/docs/library-first-command-storage.md
@@ -431,4 +431,38 @@ Do not implement this as a dual-source-of-truth system. During rollout, temporar
 
 ### Status
 
-Planned. No implementation work has started under this doc yet.
+In progress.
+
+Completed on branch work by April 11, 2026:
+
+- Phase 2 baseline: first-run default writable local library setup, manifest bootstrap, stored default library preference
+- Phase 3 baseline: local create/edit/delete now writes command JSON files when a writable local library exists, with DB fallback for legacy DB-only commands
+- Phase 4 baseline: initialized local libraries are reindexed from disk on startup so SQLite is refreshed as a derived cache/index
+- Phase 5 baseline: legacy DB-only local commands can be migrated into the default writable local library during startup
+- Phase 7 DB test recovery: `pnpm test:db` rebuilds `better-sqlite3` and reruns the SQLite test suite
+
+Still open after this session:
+
+- Phase 4 full SQLite demotion from command source of truth to cache/index beyond startup/local-library rebuild behavior
+- Phase 5 migration hardening beyond the current startup happy path
+- Phase 6 per-library command management UX
+- hardening around normalization and sync bookkeeping follow-up issues
+
+### Implementation Notes
+
+Implemented and verified on April 11, 2026:
+
+- new first-run gate in `src/App.vue` blocks command authoring until a default writable local library exists
+- `electron/main/local-library.ts` now owns default writable library resolution, manifest bootstrap, local file-backed CRUD, and legacy DB fallback
+- command JSON files now include a stable lowercase UUID `id`; edits preserve the existing file `id`
+- startup now migrates legacy DB-only commands into the default writable library when one exists, then reindexes initialized local libraries from disk
+- `electron/main/index.ts` and `electron/preload/index.ts` expose dedicated library-first CRUD and setup IPC channels
+- `src/components/SettingsModal.vue` exposes default writable library selection/change from Settings
+- `docs/db-health.md` and `package.json` document and expose the DB recovery path via `pnpm test:db`
+
+Verification run on April 11, 2026:
+
+- `pnpm vue-tsc --noEmit`
+- `pnpm vitest run tests/local-library.test.ts`
+- `pnpm vitest run tests/database.test.ts`
+- `pnpm test:db`

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1176,20 +1176,27 @@ ipcMain.handle('window:getPlatform', () => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 
-
-
-app.whenReady().then(() => {
-  createWindow()
-  createTray()
-  startAutoSync() // Start if library.autoSync is enabled
-  localLibrary.startFileWatchers()
-  localLibrary.onFileWatcherSync((_libraryId, result) => {
-    if ((result.added || result.updated || result.removed) && win && !win.isDestroyed()) {
-      win.webContents.send('commands:changed')
-    }
-  })
-  updater.setWindow(win)
-  updater.startUpdateChecker()
+app.whenReady().then(async () => {
+  try {
+    await createWindow()
+    createTray()
+    startAutoSync() // Start if library.autoSync is enabled
+    localLibrary.startFileWatchers()
+    localLibrary.onFileWatcherSync((_libraryId, result) => {
+      if ((result.added || result.updated || result.removed) && win && !win.isDestroyed()) {
+        win.webContents.send('commands:changed')
+      }
+    })
+    updater.setWindow(win)
+    updater.startUpdateChecker()
+  } catch (error) {
+    console.error('App startup failed:', error)
+    dialog.showErrorBox(
+      'SnipForge Failed To Start',
+      (error as Error).message || 'Unknown startup error'
+    )
+    app.quit()
+  }
 })
 
 app.on('window-all-closed', () => {

--- a/electron/main/local-library.ts
+++ b/electron/main/local-library.ts
@@ -699,6 +699,7 @@ export async function exportAsLibrary(input: ExportLibraryInput): Promise<string
 
         const commandData = {
             snipforge: 'command' as const,
+            id: createCommandId(),
             title: cmd.title,
             body: cmd.body,
             description: cmd.description || '',

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "dev:debug": "REMOTE_DEBUG=9222 vite",
+    "dev": "node scripts/dev-app.mjs",
+    "dev:debug": "node scripts/dev-app.mjs 9222",
     "build": "vue-tsc --noEmit && vite build && electron-builder",
     "preview": "vite preview",
     "test:db": "node scripts/test-db.mjs",

--- a/scripts/dev-app.mjs
+++ b/scripts/dev-app.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { mkdirSync } from 'node:fs'
+import path from 'node:path'
+
+const projectRoot = process.cwd()
+const cacheRoot = path.join(projectRoot, '.cache')
+const homeDir = path.join(cacheRoot, 'home')
+const npmCacheDir = path.join(cacheRoot, 'npm')
+const electronGypDir = path.join(cacheRoot, 'electron-gyp')
+
+mkdirSync(homeDir, { recursive: true })
+mkdirSync(npmCacheDir, { recursive: true })
+mkdirSync(electronGypDir, { recursive: true })
+
+function run(command, args, extraEnv = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+const debugPort = process.argv[2]
+
+// Keep the native addon ABI aligned with Electron before starting Vite dev.
+run('pnpm', ['exec', 'electron-builder', 'install-app-deps'], {
+  HOME: homeDir,
+  npm_config_cache: npmCacheDir,
+  npm_config_devdir: electronGypDir,
+})
+run('pnpm', ['exec', 'vite'], debugPort ? { REMOTE_DEBUG: debugPort } : {})


### PR DESCRIPTION
## Summary
- make a default writable local library the primary authoring surface
- move command CRUD and migration/reindex flows toward library-backed storage
- add local helper scripts for Electron dev dependency rebuilds and DB test recovery

## Validation
- pnpm exec tsc --noEmit --pretty false
- pnpm test:db
- pnpm exec vitest run tests/local-library.test.ts
